### PR TITLE
docs: Add Scikit-HEP project badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 histoprint
 ==========
 
+|Scikit-HEP|
+
 Pretty print Numpy (and other) histograms to the console
 
 
@@ -188,3 +190,6 @@ How to get it?
 ::
 
     $ pip install [--user] histoprint
+
+.. |Scikit-HEP| image:: https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
+   :target: https://scikit-hep.org/


### PR DESCRIPTION
The badge is an indicator on project pages outside of the GitHub org that the project is part of Scikit-HEP. c.f. https://scikit-hep.org/badges

[![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)