### PR TITLE
make reading of README windows/py2 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+
 # make open consistent between py2 and py3 as we need encoding param
 from io import open
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+# make open consistent between py2 and py3 as we need encoding param
+from io import open
 
 # Todo: Parse this from a proper readme file in the future
 description = "histoprint"
@@ -10,7 +12,7 @@ Pretty print numpy histograms to the console.
 
 if __name__ == "__main__":
     # Read README
-    with open("README.rst") as f:
+    with open("README.rst", mode="r", encoding="utf-8") as f:
         long_description = f.read()
 
 extras = {"test": ["pytest"]}


### PR DESCRIPTION
As outlined in #16 when reading the README in `setup.py` on windows, there are encoding problems.  

This PR adds a fix by explicitly mapping the `open()` function to the version offered in the [`io`][io] module (as `open()` in python2 does not support the required `encoding=` parameter).

Note: this version of `open()` is the same one used as the built-in method in python3 - so this change does not impact python3.


[io]: https://docs.python.org/3/library/io.html?highlight=io#io.open