### PR TITLE
fix: click breaks pyodide

### DIFF
--- a/histoprint/__init__.py
+++ b/histoprint/__init__.py
@@ -2,6 +2,6 @@
 
 from histoprint.formatter import HistFormatter, print_hist, text_hist
 
-from .version import version as __version__  # noqa: F401
+from .version import version as __version__
 
-__all__ = ("print_hist", "text_hist", "formatter", "HistFormatter")
+__all__ = ("print_hist", "text_hist", "formatter", "HistFormatter", "__version__")

--- a/histoprint/formatter.py
+++ b/histoprint/formatter.py
@@ -599,8 +599,8 @@ def print_hist(hist, file=None, **kwargs):  # noqa: B008
         file = sys.stdout
     count, edges = get_count_edges(hist)
     hist_formatter = HistFormatter(edges, **kwargs)
-    sys.stdout.write(hist_formatter.format_histogram(count))
-    sys.stdout.flush()
+    file.write(hist_formatter.format_histogram(count))
+    file.flush()
 
 
 def text_hist(*args, density=None, **kwargs):

--- a/histoprint/formatter.py
+++ b/histoprint/formatter.py
@@ -1,11 +1,11 @@
 """Module for plotting Numpy-like 1D histograms to the terminal."""
 
 import shutil
+import sys
 from collections.abc import Sequence
 from itertools import cycle
 from typing import Optional
 
-import click
 import numpy as np
 from uhi.numpy_plottable import ensure_plottable_histogram
 from uhi.typing.plottable import PlottableHistogram
@@ -583,7 +583,7 @@ def get_count_edges(hist):
     return count, edges
 
 
-def print_hist(hist, file=click.get_text_stream("stdout"), **kwargs):  # noqa: B008
+def print_hist(hist, file=None, **kwargs):  # noqa: B008
     """Plot the output of ``numpy.histogram`` to the console.
 
     Parameters
@@ -595,17 +595,19 @@ def print_hist(hist, file=click.get_text_stream("stdout"), **kwargs):  # noqa: B
         Additional keyword arguments are passed to the `HistFormatter`.
 
     """
-
+    if file is None:
+        file = sys.stdout
     count, edges = get_count_edges(hist)
     hist_formatter = HistFormatter(edges, **kwargs)
-    click.echo(hist_formatter.format_histogram(count), nl=False, file=file)
+    sys.stdout.write(hist_formatter.format_histogram(count))
+    sys.stdout.flush()
 
 
 def text_hist(*args, density=None, **kwargs):
     """Thin wrapper around ``numpy.histogram``."""
 
     print_kwargs = {
-        "file": kwargs.pop("file", click.get_text_stream("stdout")),
+        "file": kwargs.pop("file", sys.stdout),
         "title": kwargs.pop("title", ""),
         "stack": kwargs.pop("stack", False),
         "symbols": kwargs.pop("symbols", DEFAULT_SYMBOLS),


### PR DESCRIPTION
This avoids importing click and using it for the click wrapper, which seems to be primary a Python 2/3 compatibility thing. It also shaves time of the import for libraries (like hist) that do not need click imported.

Also including `__version__` in `__all__`, it was missing.
