### PR TITLE
Rename optional dependency from 'root' to 'uproot'.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,11 @@ console_scripts =
 [options.extras_require]
 boost =
     boost-histogram>=1.1
-root =
-    awkward>=1
-    uproot>=4
 test =
     pytest>=6.0
+uproot =
+    awkward>=1
+    uproot>=4
 
 [flake8]
 ignore = E203, E231, E501, E722, W503, B950


### PR DESCRIPTION
Seems like the 'root' name is reserved, since setuptools did not recognize it
when trying to instal it with pip.