### PR TITLE
ci: Add Python 3.10 to testing

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -e .[test,boost,uproot,rich]
     - name: Install optional dependencies for tests
-      run: pip install pandas
+      run: python -m pip install pandas
     - name: Run tests
       run: python -m pytest -s
     - name: Run CLI

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import nox
 
-ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9"]
+ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 nox.options.sessions = ["lint", "tests"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 
 [options]


### PR DESCRIPTION
Add Python 3.10 to testing in `nox` and in CI.

**Suggested squash and merge commit message**:

```
* Add Python 3.10 to CI testing matrix.
* Add Python 3.10 to noxfile testing.
* Add Python 3.10 to PyPI classifiers metadata.
```