### PR TITLE
test: Rename extra to 'uproot' and add 'rich' extra in nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ def tests(session):
     """
     Run the unit and regular tests.
     """
-    session.install(".[test,boost,root]")
+    session.install(".[test,boost,uproot,rich]")
     session.run("pytest", "-s", *session.posargs)
 
 


### PR DESCRIPTION
* The 'root' extra was renamed to 'uproot' in v2.3.0.
   - c.f. https://github.com/scikit-hep/histoprint/releases/tag/v2.3.0
* The 'rich' extra was addded in v2.4.0.
   - c.f. https://github.com/scikit-hep/histoprint/releases/tag/v2.4.0