### PR TITLE
feat: drop Python 3.8

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Support for Python 3.8.
+
 ## [2.6.0]
 
 ### Removed

--- a/histoprint/cli.py
+++ b/histoprint/cli.py
@@ -2,7 +2,7 @@
 
 import contextlib
 from io import StringIO
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import click
 import numpy as np
@@ -199,7 +199,7 @@ def _histoprint_txt(infile, **kwargs):
     bins = _bin_edges(kwargs, data)
 
     # Create the histogram(s)
-    hist: Tuple[Any, Any] = ([], bins)
+    hist: tuple[Any, Any] = ([], bins)
     for d in data:
         hist[0].append(np.histogram(d, bins=bins)[0])
 
@@ -243,7 +243,7 @@ def _histoprint_csv(infile, **kwargs):
     bins = _bin_edges(kwargs, data)
 
     # Create the histogram(s)
-    hist: Tuple[Any, Any] = ([], bins)
+    hist: tuple[Any, Any] = ([], bins)
     for d in data:
         hist[0].append(np.histogram(d, bins=bins)[0])
 
@@ -303,8 +303,8 @@ def _histoprint_root(infile, **kwargs):
 
     data = []
     # Find TTrees
-    trees: List[up.models.TTree.Model_TTree_v19] = []
-    tree_fields: List[List[Dict[str, Any]]] = []
+    trees: list[up.models.TTree.Model_TTree_v19] = []
+    tree_fields: list[list[dict[str, Any]]] = []
     for field, label in zip(fields, labels):
         branch = F
         splitfield = field.split("/")
@@ -384,7 +384,7 @@ def _histoprint_root(infile, **kwargs):
     bins = _bin_edges(kwargs, data)
 
     # Create the histogram(s)
-    hist_data: Tuple[List[np.ndarray], np.ndarray] = ([], bins)
+    hist_data: tuple[list[np.ndarray], np.ndarray] = ([], bins)
     for d in data:
         hist_data[0].append(np.histogram(d, bins=bins)[0])
 

--- a/histoprint/formatter.py
+++ b/histoprint/formatter.py
@@ -1,10 +1,11 @@
 """Module for plotting Numpy-like 1D histograms to the terminal."""
 
+from __future__ import annotations
+
 import shutil
 import sys
 from collections.abc import Sequence
 from itertools import cycle
-from typing import Optional
 
 import numpy as np
 from uhi.numpy_plottable import ensure_plottable_histogram
@@ -23,7 +24,7 @@ class Hixel:
 
     def __init__(self, char=" ", fg="0", bg="0", use_color=True, compose=" "):
         self.character = " "
-        self.compose: Optional[str] = compose
+        self.compose: str | None = compose
         self.fg_color = fg
         self.bg_color = bg
         self.use_color = use_color
@@ -231,7 +232,7 @@ class BinFormatter:
                 self.use_color = False
         else:
             self.use_color = use_color
-        self.compose: Optional[str] = None
+        self.compose: str | None = None
 
     def format_bin(self, top, bottom, counts, width=1):
         """Return a string that represents the bin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Pretty print of NumPy (and other) histograms to the console"
 readme = "README.rst"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Lukas Koch", email = "lukas.koch@mailbox.org" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -79,7 +78,7 @@ testpaths = [
 
 [tool.mypy]
 files = ["histoprint"]
-python_version = "3.8"
+python_version = "3.9"
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unused_configs = true


### PR DESCRIPTION
Dropping 3.8, which has been dropped in most other Scikit-HEP repos. (In fact, 3.9 has too).

:robot: Assisted-by: Copilot:GPT-5.4
