### PR TITLE
chore: use dependency-groups

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -25,21 +25,21 @@ jobs:
     - name: Setup uv
       uses: astral-sh/setup-uv@v8.0.0
     - name: Install dependencies
-      run: uv pip install --system -e .[test,boost,uproot,rich] pandas
+      run: uv sync
     - name: Run tests
-      run: python -m pytest -s
+      run: uv run pytest -s
     - name: Run CLI
       run: |
-        histoprint tests/data/1D.txt
-        histoprint tests/data/1D.txt -c 40 -l 40
-        histoprint tests/data/2D.txt
-        histoprint tests/data/3D.txt -s -l A -l B -l C -t "HISTOPRINT"
-        histoprint tests/data/3D.txt -s -f 0 -l A -f 2 -l C -C 'data[1] > 2.'
-        histoprint tests/data/3D.csv -s -f x -f z -C 'y > 2.'
+        uv run histoprint tests/data/1D.txt
+        uv run histoprint tests/data/1D.txt -c 40 -l 40
+        uv run histoprint tests/data/2D.txt
+        uv run histoprint tests/data/3D.txt -s -l A -l B -l C -t "HISTOPRINT"
+        uv run histoprint tests/data/3D.txt -s -f 0 -l A -f 2 -l C -C 'data[1] > 2.'
+        uv run histoprint tests/data/3D.csv -s -f x -f z -C 'y > 2.'
         wget --quiet http://scikit-hep.org/uproot3/examples/Event.root
-        histoprint -s Event.root -f T/event/fTracks/fTracks.fYfirst -f T/event/fTracks/fTracks.fYlast[:,0]
-        histoprint -s Event.root -f T/fTracks.fYfirst -f T/event/fTracks/fTracks.fYlast[:,0] -C 'fNtrack > 5'
-        histoprint -s Event.root -f htime
+        uv run histoprint -s Event.root -f T/event/fTracks/fTracks.fYfirst -f T/event/fTracks/fTracks.fYlast[:,0]
+        uv run histoprint -s Event.root -f T/fTracks.fYfirst -f T/event/fTracks/fTracks.fYlast[:,0] -C 'fNtrack > 5'
+        uv run histoprint -s Event.root -f htime
 
   pre-commit:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.15.10"
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --show-fixes]
   - id: ruff-format
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import nox
 
-nox.needs_version = ">=2024.4.15"
+nox.needs_version = ">=2025.02.09"
 nox.options.default_venv_backend = "uv|virtualenv"
 
-ALL_PYTHONS = [
-    c.split()[-1]
-    for c in nox.project.load_toml("pyproject.toml")["project"]["classifiers"]
-    if c.startswith("Programming Language :: Python :: 3.")
-]
+PYPROJECT = nox.project.load_toml("pyproject.toml")
+PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 
 
 @nox.session
@@ -17,16 +14,16 @@ def lint(session):
     """
     Run the linter.
     """
-    session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
+    session.install("prek")
+    session.run("prek", "run", "--all-files", *session.posargs)
 
 
-@nox.session(python=ALL_PYTHONS)
+@nox.session(python=PYTHON_VERSIONS)
 def tests(session):
     """
     Run the unit and regular tests.
     """
-    session.install(".[test,boost,uproot,rich]")
+    session.install("-e.[boost,uproot,rich]", "--group=test")
     session.run("pytest", "-s", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,18 @@ boost = [
 rich = [
     "rich>=12",
 ]
-test = [
-    "pytest>=6.0",
-]
 uproot = [
     "awkward>=1",
     "uproot>=4",
 ]
+
+[dependency-groups]
+dev = [
+    { include-group = "test" },
+    "histoprint[boost,rich,uproot]",
+    "pandas",
+]
+test = ["pytest>=6.0"]
 
 [project.scripts]
 histoprint = "histoprint.cli:histoprint"
@@ -62,11 +67,6 @@ build.hooks.vcs.version-file = "histoprint/version.py"
 
 [tool.setuptools_scm]
 write_to = "histoprint/version.py"
-
-
-[tool.uv]
-dev-dependencies = ["histoprint[boost,rich,test,uproot]", "pandas"]
-environments = ["python_version >= '3.11'"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Some modernization, mostly adding dependency groups instead of the deprecated custom uv setting.
