### PR TITLE
chore: move to PEP 735 dependency-groups, drop dead config, add Python 3.14

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ Homepage = "https://github.com/scikit-hep/histoprint"
 version.source = "vcs"
 build.hooks.vcs.version-file = "histoprint/version.py"
 
+[tool.setuptools_scm]
+write_to = "histoprint/version.py"
 
 [tool.uv]
 environments = ["python_version >= '3.11'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
@@ -59,13 +60,11 @@ version.source = "vcs"
 build.hooks.vcs.version-file = "histoprint/version.py"
 
 
-[tool.setuptools_scm]
-write_to = "histoprint/version.py"
-
-
 [tool.uv]
-dev-dependencies = ["histoprint[boost,rich,test,uproot]", "pandas"]
 environments = ["python_version >= '3.11'"]
+
+[dependency-groups]
+dev = ["histoprint[boost,rich,test,uproot]", "pandas"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,18 +55,21 @@ histoprint = "histoprint.cli:histoprint"
 Homepage = "https://github.com/scikit-hep/histoprint"
 
 
+[dependency-groups]
+dev = ["histoprint[boost,rich,test,uproot]", "pandas"]
+
+
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "histoprint/version.py"
 
+
 [tool.setuptools_scm]
 write_to = "histoprint/version.py"
 
+
 [tool.uv]
 environments = ["python_version >= '3.11'"]
-
-[dependency-groups]
-dev = ["histoprint[boost,rich,test,uproot]", "pandas"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- Replace deprecated `[tool.uv] dev-dependencies` with PEP 735 `[dependency-groups]` to silence uv's deprecation warning on every invocation
- Add `Programming Language :: Python :: 3.14` classifier; `noxfile.py` already derives `ALL_PYTHONS` from classifiers, so `tests-3.14` appears automatically in nox sessions
- Add `"3.14"` to the test matrix in `.github/workflows/pythontests.yml`

Addresses the modernization items of #159

## Test plan

- [x] `uv run python -c "import histoprint"` — no deprecation warning
- [x] `uv run python -m pytest -s` — 7 passed
- [x] `uv run --with nox nox -l` — shows `tests-3.14` session
- [x] `uv run --with build python -m build` — sdist and wheel built successfully
- [x] `uv run --with pre-commit pre-commit run --all-files` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)