### PR TITLE
fix: formatter edge cases (compose collisions, integer edges) and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- All-zero or degenerate bin edges no longer print an `x 10^+nan` exponent.
+- Composing a symbol onto an existing `X` glyph keeps the glyph.
+
+### Changed
+- Discrete axes, mismatched bin edges, and empty input sequences now raise clear
+  `TypeError`/`ValueError` messages instead of an assertion or a test helper.
+
 ## [2.7.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error instead of a traceback or a histogram of `nan` edges (issue #159).
 - Giving fewer `--label` options than `--field` options for a ROOT file now
   shows a clear error instead of dropping the extra fields (issue #159).
+- All-zero or degenerate bin edges no longer print an `x 10^+nan` exponent.
+- Composing a symbol onto an existing `X` glyph keeps the glyph.
+
+### Changed
+- Discrete axes, mismatched bin edges, and empty input sequences now raise clear
+  `TypeError`/`ValueError` messages instead of an assertion or a test helper.
 
 ## [2.7.0]
 

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -462,12 +462,9 @@ class HistFormatter:
         # Get bin edges
         top = np.array(self.edges[:-1])
         bottom = np.array(self.edges[1:])
-        # Calculate common exponent
-        max_edge = np.max(np.abs(self.edges))
-        if max_edge == 0:
-            common_exponent = 0.0
-        else:
-            common_exponent = np.floor(np.log10(max_edge))
+        # Calculate common exponent, guarding against all-zero edges
+        max_edge = float(np.max(np.abs(self.edges)))
+        common_exponent = 0.0 if max_edge == 0 else np.floor(np.log10(max_edge))
         top /= 10**common_exponent
         bottom /= 10**common_exponent
 

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -127,7 +127,7 @@ class Hixel:
         ret = subs.get(char, char)
         # Characters can be displayed differently when they have a composing character on top.
         # This looks ugly if some Hixels of a histogram are covered by another and some are not.
-        # Unless explicitly asked for no compositio, if no composition is added,
+        # Unless explicitly asked for no composition, if no composition is added,
         # use empty composition character to make them all display the same.
         ret += subs.get(compose, "\u034f")
 
@@ -225,21 +225,12 @@ class BinFormatter:
         self.tick_mark = tick_mark
         self.no_tick_mark = no_tick_mark
         self.print_top_edge = print_top_edge
-        self.symbols = symbols
-        if self.symbols == "":
-            self.symbols = " "
-        self.fg_colors = fg_colors
-        if self.fg_colors == "":
-            self.fg_colors = "0"
-        self.bg_colors = bg_colors
-        if self.bg_colors == "":
-            self.bg_colors = "0"
+        self.symbols = symbols or " "
+        self.fg_colors = fg_colors or "0"
+        self.bg_colors = bg_colors or "0"
         self.stack = stack
         if use_color is None:
-            if any(c != "0" for c in fg_colors) or any(c != "0" for c in bg_colors):
-                self.use_color = True
-            else:
-                self.use_color = False
+            self.use_color = any(c != "0" for c in fg_colors + bg_colors)
         else:
             self.use_color = use_color
         self.compose: str | None = None
@@ -299,7 +290,7 @@ class BinFormatter:
             ):
                 if h:
                     if self.stack:
-                        # Just print them all afer one another
+                        # Just print them all after one another
                         line += [
                             Hixel(s, fg, bg, self.use_color, self.compose)
                             for _ in range(h)
@@ -334,13 +325,13 @@ class BinFormatter:
 
 
 class HistFormatter:
-    """Class that handles the formating of histograms.
+    """Class that handles the formatting of histograms.
 
     Parameters
     ----------
 
     lines, columns : int, optional
-        The number of lines and maximum numbre of columns of the output.
+        The number of lines and maximum number of columns of the output.
     count_area : bool, optional
         Whether the bin content is represented by the area or height of the bin.
     scale_bin_width : bool, optional
@@ -384,10 +375,10 @@ class HistFormatter:
         # Fit histograms into the terminal, unless otherwise specified
         term_size = shutil.get_terminal_size()
         if columns is None:
-            columns = term_size[0] - 1
+            columns = term_size.columns - 1
         if lines is None:
             # Try to keep a constant aspect ratio
-            lines = min(int(columns / 3.5) + 1, term_size[1] - 1)
+            lines = min(int(columns / 3.5) + 1, term_size.lines - 1)
         self.lines = lines
         self.columns = columns
         self.summary = summary
@@ -395,11 +386,10 @@ class HistFormatter:
         self.max_count = max_count
 
         self.hist_lines = lines - 1  # Less one line for the first tick
-        if len(self.title):
+        if self.title:
             # Make room for the title
             self.hist_lines -= 1
 
-        self.summary = summary
         if self.summary:
             # Make room for a summary at the bottom
             self.hist_lines -= 4
@@ -427,8 +417,8 @@ class HistFormatter:
     def format_histogram(self, counts):
         """Format (a set of) histogram counts.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
 
         counts : ndarray
             The histogram entries to be plotted.

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -279,15 +279,15 @@ class BinFormatter:
             self.compose = None
 
         # Format bin
-        bin_string = ""
+        bin_string = []
         for i_line in range(width):
             # Print axis
             if self.print_top_edge and i_line == 0:
-                bin_string += self.tick(top)
+                bin_string.append(self.tick(top))
             elif not self.print_top_edge and i_line == (width - 1):
-                bin_string += self.tick(bottom)
+                bin_string.append(self.tick(bottom))
             else:
-                bin_string += self.no_tick()
+                bin_string.append(self.no_tick())
 
             # Print symbols
             line = []
@@ -317,12 +317,12 @@ class BinFormatter:
                             hix.add(s, fg, bg)
 
             for hix in line:
-                bin_string += hix.render()
+                bin_string.append(hix.render())
 
             # New line
-            bin_string += "\n"
+            bin_string.append("\n")
 
-        return bin_string
+        return "".join(bin_string)
 
     def tick(self, edge):
         """Format the tick mark of a bin."""
@@ -463,11 +463,11 @@ class HistFormatter:
         symbol_scale = max_c / hist_width
         self.bin_formatter.scale = symbol_scale * 0.999  # <- avoid rounding issues
 
-        hist_string = ""
+        hist_string = []
 
         # Write the title line
-        if len(self.title):
-            hist_string += f"{self.title: ^{self.columns:d}s}\n"
+        if self.title:
+            hist_string.append(f"{self.title: ^{self.columns:d}s}\n")
 
         # Get bin edges
         top = np.array(self.edges[:-1])
@@ -482,37 +482,38 @@ class HistFormatter:
         bottom /= 10**common_exponent
 
         # Write the first tick, common exponent and horizontal axis
-        hist_string += self.bin_formatter.tick(top[0])
+        hist_string.append(self.bin_formatter.tick(top[0]))
         ce_string = f" x 10^{common_exponent:+03.0f}" if common_exponent != 0 else ""
 
-        hist_string += ce_string
+        hist_string.append(ce_string)
         if self.bin_formatter.count_area:
             longest_count = f"{max_c:g}/row"
         else:
             longest_count = f"{max_c:g}"
-        hist_string += f"{longest_count:>{hist_width - len(ce_string) - 2:d}s} \u2577\n"
+        hist_string.append(
+            f"{longest_count:>{hist_width - len(ce_string) - 2:d}s} \u2577\n"
+        )
 
         # Write the bins
         for c, t, b, w in zip(counts.T, top, bottom, self.bin_lines, strict=True):
-            hist_string += self.bin_formatter.format_bin(t, b, c, w)
+            hist_string.append(self.bin_formatter.format_bin(t, b, c, w))
 
         if self.summary:
-            hist_string += self.summarize(counts, top, bottom)
+            hist_string.append(self.summarize(counts, top, bottom))
         elif any(len(lab) > 0 for lab in self.labels):
-            hist_string += self.summarize(counts, top, bottom, legend_only=True)
+            hist_string.append(self.summarize(counts, top, bottom, legend_only=True))
 
-        return hist_string
+        return "".join(hist_string)
 
     def summarize(self, counts, top, bottom, legend_only=False):
         """Calculate some summary statistics."""
 
-        summary = ""
         bin_values = (top + bottom) / 2
 
         label_widths = []
 
         # First line: symbol, label
-        summary += "     "
+        first_line = ["     "]
         for _, lab, s, fg, bg in zip(
             counts,
             cycle(self.labels),
@@ -522,49 +523,47 @@ class HistFormatter:
         ):
             # Pad label to make room for numbers below
             pad_lab = f"{lab:<9}"
-            label = " "
-            label += Hixel(
+            hixel = Hixel(
                 s, fg, bg, self.bin_formatter.use_color, self.bin_formatter.compose
             ).render()
-            label += " " + pad_lab
+            first_line.append(f" {hixel} {pad_lab}")
             label_widths.append(3 + len(pad_lab))
-            summary += label
         pad = max(self.columns - (5 + np.sum(label_widths)), 0) // 2
-        summary = " " * pad + summary
-        summary += "\n"
+
+        summary = [" " * pad, *first_line, "\n"]
 
         if legend_only:
-            return summary
+            return "".join(summary)
 
         # Second line: Total
-        summary += " " * pad + "Tot:"
+        summary.append(" " * pad + "Tot:")
         for c, w in zip(counts, label_widths, strict=True):
             tot = float(np.sum(c))
-            summary += f" {tot: .2e}" + " " * (w - 10)
-        summary += "\n"
+            summary.append(f" {tot: .2e}" + " " * (w - 10))
+        summary.append("\n")
 
         # Third line: Average
-        summary += " " * pad + "Avg:"
+        summary.append(" " * pad + "Avg:")
         for c, w in zip(counts, label_widths, strict=True):
             try:
                 average = float(np.average(bin_values, weights=c))
             except ZeroDivisionError:
                 average = np.nan
-            summary += f" {average: .2e}" + " " * (w - 10)
-        summary += "\n"
+            summary.append(f" {average: .2e}" + " " * (w - 10))
+        summary.append("\n")
 
         # Fourth line: std
-        summary += " " * pad + "Std:"
+        summary.append(" " * pad + "Std:")
         for c, w in zip(counts, label_widths, strict=True):
             try:
                 average = float(np.average(bin_values, weights=c))
                 std = np.sqrt(np.average((bin_values - average) ** 2, weights=c))
             except ZeroDivisionError:
                 std = np.nan
-            summary += f" {std: .2e}" + " " * (w - 10)
-        summary += "\n"
+            summary.append(f" {std: .2e}" + " " * (w - 10))
+        summary.append("\n")
 
-        return summary
+        return "".join(summary)
 
 
 def get_plottable_protocol_bin_edges(axis):

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -35,7 +35,7 @@ class Hixel:
 
         allowed = r" =|\/"
         if char not in allowed:
-            msg = f"Symbol not one of the allowed: '{allowed!r}'"
+            msg = f"Symbol not one of the allowed: {allowed!r}"
             raise ValueError(msg)
 
         if fg == self.fg_color:
@@ -60,7 +60,12 @@ class Hixel:
             }
             if char in compose_chars:
                 if self.compose is not None:
-                    self.compose = compose_combinations.get((self.compose, char))
+                    # Fall back to the existing composing character (e.g. when
+                    # re-adding the same symbol, or composing onto an "X") so
+                    # the glyph is never erased.
+                    self.compose = compose_combinations.get(
+                        (self.compose, char), self.compose
+                    )
             else:
                 self.character = char_combinations.get((self.character, char), char)
         elif char != " ":
@@ -467,8 +472,12 @@ class HistFormatter:
         # Get bin edges
         top = np.array(self.edges[:-1])
         bottom = np.array(self.edges[1:])
-        # Caclucate common exponent
-        common_exponent = np.floor(np.log10(np.max(np.abs(self.edges))))
+        # Calculate common exponent
+        max_edge = np.max(np.abs(self.edges))
+        if max_edge == 0:
+            common_exponent = 0.0
+        else:
+            common_exponent = np.floor(np.log10(max_edge))
         top /= 10**common_exponent
         bottom /= 10**common_exponent
 
@@ -566,9 +575,9 @@ def get_plottable_protocol_bin_edges(axis):
     """
 
     out = np.empty(len(axis) + 1)
-    assert isinstance(axis[0], tuple), (
-        f"Currently only support non-discrete axes {axis}"
-    )
+    if not isinstance(axis[0], tuple):
+        msg = f"Currently only support non-discrete axes {axis}"
+        raise TypeError(msg)
     # TODO: Support discreete axes
     out[0] = axis[0][0]
     out[1:] = [axis[i][1] for i in range(len(axis))]
@@ -579,13 +588,19 @@ def get_count_edges(hist):
     """Get bin contents and edges from a compatible histogram."""
 
     # Support sequence of histograms
+    if isinstance(hist, Sequence) and len(hist) == 0:
+        msg = "Cannot plot an empty sequence of histograms"
+        raise ValueError(msg)
+
     if isinstance(hist, Sequence) and isinstance(hist[0], PlottableHistogram):
         count = np.stack([h.values() for h in hist])
         edges = get_plottable_protocol_bin_edges(hist[0].axes[0])
         for other_edges in (
             get_plottable_protocol_bin_edges(h.axes[0]) for h in hist[1:]
         ):
-            np.testing.assert_allclose(edges, other_edges)
+            if not np.allclose(edges, other_edges):
+                msg = "All histograms must share the same bin edges"
+                raise ValueError(msg)
 
     else:
         # Single histogram or (a,b,c, edges) tuple:

--- a/src/histoprint/rich.py
+++ b/src/histoprint/rich.py
@@ -1,4 +1,4 @@
-"""Module montaining classes that support the `rich` console protocol."""
+"""Module containing classes that support the `rich` console protocol."""
 
 from rich.text import Text
 
@@ -10,7 +10,7 @@ __all__ = ["RichHistogram"]
 class RichHistogram:
     """Histogram object that supports `Rich`'s `Console Protocol`.
 
-    Ths provided `hist` is kept as a reference, so it is possible to update its
+    The provided `hist` is kept as a reference, so it is possible to update its
     contents after the creation of the RichHistogram.
 
     Parameters

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,11 +1,13 @@
 import contextlib
 import io
+import warnings
 
 import numpy as np
 import pytest
 from uhi.numpy_plottable import ensure_plottable_histogram
 
 import histoprint as hp
+from histoprint.formatter import HistFormatter, Hixel
 
 
 def test_hist():
@@ -113,15 +115,6 @@ def test_uproot():
     hp.print_hist(hist, title="uproot TH1")
 
 
-def test_integer_edges():
-    """Integer bin edges should not crash HistFormatter (bug 3, #159)."""
-    hist = (np.array([1, 2, 3, 4]), np.arange(5))
-    hp.print_hist(hist, use_color=False)
-    # Also test plain Python list edges
-    hist = (np.array([1, 2, 3, 4]), [0.0, 1.0, 2.0, 3.0, 4.0])
-    hp.print_hist(hist, use_color=False)
-
-
 def test_stack():
     A = np.random.randn(1000) - 2
     B = np.random.randn(1000)
@@ -195,3 +188,45 @@ def test_rich_histogram():
     tab.add_row(hist, Align.center(hist), Align.right(hist))
 
     rich.print(tab)
+
+
+def test_hixel_same_symbol_overlay():
+    """Re-adding the same composing symbol must keep the glyph (issue #159)."""
+    h = Hixel("/", "W", "0", use_color=False, compose=" ")
+    h.add("/", "W", "0")
+    # The composing character must survive, not be erased to None.
+    assert h.compose == "/"
+    # And the rendered Hixel must still contain the "/" composing glyph.
+    assert "⃫" in h.render()
+
+
+def test_integer_edges():
+    """Integer bin edges must not crash the formatter (issue #159)."""
+    # Through HistFormatter directly.
+    HistFormatter(np.arange(5), columns=40).format_histogram(np.zeros(4))
+
+    # Through print_hist with an integer-edge tuple.
+    f = io.StringIO()
+    hist = (np.array([1, 2, 3, 4]), np.arange(5))
+    hp.print_hist(hist, file=f, columns=40, use_color=False)
+    assert f.getvalue()
+
+    # And with plain Python list edges.
+    hist = (np.array([1, 2, 3, 4]), [0.0, 1.0, 2.0, 3.0, 4.0])
+    hp.print_hist(hist, file=io.StringIO(), columns=40, use_color=False)
+
+
+def test_degenerate_edges_no_warning():
+    """All-zero / degenerate edges must not emit numpy RuntimeWarnings."""
+    f = io.StringIO()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        hp.print_hist((np.zeros(4), np.zeros(5)), file=f, columns=40, use_color=False)
+    # The bogus "x 10^+nan" exponent label must not appear.
+    assert "nan" not in f.getvalue()
+
+
+def test_empty_list_raises():
+    """An empty input sequence must raise a clear ValueError (issue #159)."""
+    with pytest.raises(ValueError, match="empty"):
+        hp.print_hist([], file=io.StringIO())


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes a set of edge-case bugs in `histoprint/formatter.py` and applies some related cleanups.

## Bug fixes
- **Compose-symbol collision erased the glyph.** `Hixel.add` returned `None` from `compose_combinations.get` when the same composing symbol was added twice (e.g. two histograms both using `/`) or when anything was composed onto an existing `X`, blanking the cell. It now falls back to the current composing character, and `("/","/")` / `("\\","\\")` are explicit identity entries.
- **Integer / list bin edges crashed `HistFormatter`.** Edges are now converted with `np.asarray(edges, dtype=float)` once in `__init__`, so integer edges no longer raise `UFuncTypeError` on the in-place exponent scaling, and plain-list edges are safe for the edge-difference arithmetic.
- **All-zero edges** no longer emit numpy `RuntimeWarning`s or render `x 10^+nan`; the common exponent falls back to `0`.
- **Error-message quoting**: dropped the doubled quotes around `{allowed!r}`.
- **Validation robustness**: replaced an `assert` and `np.testing.assert_allclose` with raised `ValueError`s (survives `python -O`, no `AssertionError` from library code) and added a clear `ValueError` for empty input sequences.

## Cleanups
- Removed a duplicated `self.summary` assignment; collapsed the empty-string symbol/color defaults and the `use_color` default; `if len(self.title)` -> `if self.title`; terminal size via `.columns` / `.lines`.
- `format_bin`, `format_histogram`, and `summarize` now accumulate with list-append + `"".join()` instead of `+=` on strings (output is byte-identical, guarded by the exact-match assertion in `test_stack`).
- Fixed several docstring typos in `formatter.py` and `rich.py`.

## Tests
Added regression tests in `tests/test_basic.py` for the same-symbol overlay, integer edges (through `HistFormatter` and `print_hist`), degenerate all-zero edges not warning, and empty input raising `ValueError`.

Addresses the formatter items of #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
