### PR TITLE
fix: add identity entries to compose_combinations to prevent glyph erasure (bug 2, #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Out-of-range `--field` on text files now shows "Field out of bounds." instead of a raw traceback (issue #159).
+- Overlaying the same composing symbol no longer erases the glyph (issue #159).
 
 ### Removed
 - Support for Python 3.8, 3.9.

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -52,6 +52,11 @@ class Hixel:
                 ("\\", "/"): "X",
                 (" ", "\\"): "\\",
                 (" ", "/"): "/",
+                ("/", "/"): "/",
+                ("\\", "\\"): "\\",
+                ("X", "/"): "X",
+                ("X", "\\"): "X",
+                ("X", "X"): "X",
             }
             if char in compose_chars:
                 if self.compose is not None:


### PR DESCRIPTION
Fixes bug 2 from #159 — overlaying the same composing symbol (e.g. `/` on `/`, or `\\` on `\\`) with the same fg color erased the glyph because `compose_combinations.get` returned `None` for missing identity entries. After the second `add`, `compose` became `None` and the hixel rendered as a bare space.

Adds identity entries for `("/", "/")`, `("\\", "\\")`, `("X", "X")`, plus stability entries for `("X", "/")` and `("X", "\\")` so that overlaying onto an existing intersection preserves the `"X"`.