### PR TITLE
fix: convert edges to float array in __init__ (bug 3, #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Out-of-range `--field` on text files now shows "Field out of bounds." instead of a raw traceback (issue #159).
 - Overlaying the same composing symbol no longer erases the glyph (issue #159).
+- Integer bin edges and plain list edges no longer crash `HistFormatter` (bug 3, issue #159).
 
 ### Removed
 - Support for Python 3.8, 3.9.

--- a/src/histoprint/formatter.py
+++ b/src/histoprint/formatter.py
@@ -375,7 +375,7 @@ class HistFormatter:
         **kwargs,
     ):
         self.title = title
-        self.edges = edges
+        self.edges = np.asarray(edges, dtype=float)
         # Fit histograms into the terminal, unless otherwise specified
         term_size = shutil.get_terminal_size()
         if columns is None:
@@ -406,16 +406,16 @@ class HistFormatter:
             # Try to scale bins so the number of lines is
             # roughly proportional to the bin width
             line_scale = (
-                (edges[-1] - edges[0]) / self.hist_lines
+                (self.edges[-1] - self.edges[0]) / self.hist_lines
             ) * 0.999  # <- avoid rounding issues
         else:
             # Choose the largest bin as scale,
             # so all bins will scale to <= 1 lines
             # and be rendered with one line
-            line_scale = np.max(edges[1:] - edges[:-1])
+            line_scale = np.max(self.edges[1:] - self.edges[:-1])
         if line_scale == 0.0:
             line_scale = 1.0
-        self.bin_lines = ((edges[1:] - edges[:-1]) // line_scale).astype(int)
+        self.bin_lines = ((self.edges[1:] - self.edges[:-1]) // line_scale).astype(int)
         self.bin_lines = np.where(self.bin_lines, self.bin_lines, 1)
         self.bin_formatter = BinFormatter(**kwargs)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -113,6 +113,15 @@ def test_uproot():
     hp.print_hist(hist, title="uproot TH1")
 
 
+def test_integer_edges():
+    """Integer bin edges should not crash HistFormatter (bug 3, #159)."""
+    hist = (np.array([1, 2, 3, 4]), np.arange(5))
+    hp.print_hist(hist, use_color=False)
+    # Also test plain Python list edges
+    hist = (np.array([1, 2, 3, 4]), [0.0, 1.0, 2.0, 3.0, 4.0])
+    hp.print_hist(hist, use_color=False)
+
+
 def test_stack():
     A = np.random.randn(1000) - 2
     B = np.random.randn(1000)


### PR DESCRIPTION
Integer bin edges (e.g. `np.arange(5)`) crashed `HistFormatter` with a `UFuncTypeError` because `np.array(self.edges[:-1])` kept the int dtype and `top /= 10**common_exponent` cannot cast in-place to float. Plain Python list edges crashed with `TypeError` on list subtraction.

**Fix:** convert edges to `np.asarray(..., dtype=float)` once in `__init__` and use `self.edges` for all downstream arithmetic.

Closes bug 3 of #159.